### PR TITLE
Add HasBasis instances for Maybe, (:->:), (:-*)

### DIFF
--- a/src/Data/Basis.hs
+++ b/src/Data/Basis.hs
@@ -21,6 +21,7 @@ module Data.Basis (HasBasis(..), linearCombo, recompose) where
 
 -- import Control.Applicative ((<$>))
 import Control.Arrow (first)
+import Data.MemoTrie
 import Data.Ratio
 import Foreign.C.Types (CFloat, CDouble)
 -- import Data.Either
@@ -114,6 +115,19 @@ unnest3 (a,(b,c)) = (a,b,c)
 
 nest3 :: (a,b,c) -> (a,(b,c))
 nest3 (a,b,c) = (a,(b,c))
+
+
+instance (HasBasis v, AdditiveGroup (Scalar v)) => HasBasis (Maybe v) where
+  type Basis (Maybe v) = Basis v
+  basisValue = Just . basisValue
+  decompose = maybe [] decompose
+  decompose' = maybe (const zeroV) decompose'
+
+instance (Eq a, HasTrie a, HasBasis v) => HasBasis (a :->: v) where
+  type Basis (a :->: v) = (a, Basis v)
+  basisValue (a, b) = trie $ \a' -> if a == a' then basisValue b else zeroV
+  decompose t = [((a, b), w) | (a, v) <- enumerate t, (b, w) <- decompose v]
+  decompose' t (a, b) = decompose' (untrie t a) b
 
 
 -- instance (Eq a, HasBasis u) => HasBasis (a -> u) where

--- a/src/Data/LinearMap.hs
+++ b/src/Data/LinearMap.hs
@@ -64,6 +64,13 @@ instance (HasTrie (Basis u), VectorSpace v) =>
 -- in the constraint: HasTrie (Basis u)
 -- (Use UndecidableInstances to permit this)
 
+instance (Eq (Basis u), HasTrie (Basis u), HasBasis v, AdditiveGroup (Scalar v)) =>
+         HasBasis (u :-* v) where
+  type Basis (u :-* v) = (Basis u, Basis v)
+  basisValue = LMap . fmap Sum . basisValue
+  decompose = decompose . fmap getSum . unLMap
+  decompose' = decompose' . fmap getSum . unLMap
+
 exlL :: ( HasBasis a, HasTrie (Basis a), HasBasis b, HasTrie (Basis b)
         , Scalar a ~ Scalar b )
      => (a,b) :-* a


### PR DESCRIPTION
`Maybe`, `(:->:)`, `(:-*)` already have `VectorSpace` instances, so why not give them compatible `HasBasis` instances too.

By the way, can I ask why `:-*` is defined in terms of `Sum`?  As far as I can tell, the point of `Sum` is to create a `Monoid` instance, but that’s not used or exposed in the context of linear maps.  So it seems to just add extra wrapping overhead.
