### PR TITLE
[fix] preprocessing errors on clang osx

### DIFF
--- a/src/Data/Basis.hs
+++ b/src/Data/Basis.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TypeOperators, TypeFamilies, UndecidableInstances
-  , FlexibleInstances, MultiParamTypeClasses, CPP
-  #-}
+  , FlexibleInstances, MultiParamTypeClasses, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
 ----------------------------------------------------------------------
 -- |

--- a/src/Data/Cross.hs
+++ b/src/Data/Cross.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances, FlexibleContexts, TypeOperators
-           , TypeFamilies, TypeSynonymInstances
-  #-}
+           , TypeFamilies, TypeSynonymInstances #-}
 {-# OPTIONS_GHC -Wall #-}
 ----------------------------------------------------------------------
 -- |

--- a/src/Data/Horner.hs
+++ b/src/Data/Horner.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TypeOperators, MultiParamTypeClasses
-           , TypeSynonymInstances, FlexibleInstances
-  #-}
+           , TypeSynonymInstances, FlexibleInstances #-}
 {-# OPTIONS_GHC -Wall #-}
 ----------------------------------------------------------------------
 -- |

--- a/src/Data/Maclaurin.hs
+++ b/src/Data/Maclaurin.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE TypeOperators, MultiParamTypeClasses, UndecidableInstances
            , TypeSynonymInstances, FlexibleInstances
            , FlexibleContexts, TypeFamilies
-           , ScopedTypeVariables
-  #-}
+           , ScopedTypeVariables #-}
 
 -- The ScopedTypeVariables is there just as a bug work-around.  Without it
 -- I get a bogus error about context mismatch for mutually recursive

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, TypeOperators
            , TypeFamilies, UndecidableInstances, CPP
-           , FlexibleContexts
- #-}
+           , FlexibleContexts #-}
 {-# OPTIONS_GHC -Wall #-}
 ----------------------------------------------------------------------
 -- |


### PR DESCRIPTION
same as conal/MemoTrie#2

to me it seems like cosmetic changes, to clang it's a preprocessor error.
