### PR TITLE
Affine Combinations

### DIFF
--- a/src/Data/AffineSpace.hs
+++ b/src/Data/AffineSpace.hs
@@ -13,12 +13,13 @@
 
 module Data.AffineSpace
   (
-    AffineSpace(..), (.-^), distanceSq, distance, alerp
+    AffineSpace(..), (.-^), distanceSq, distance, alerp, affineCombo
   ) where
 
 import Control.Applicative (liftA2)
 import Data.Ratio
 import Foreign.C.Types (CFloat, CDouble)
+import Control.Arrow(first)
 
 import Data.VectorSpace
 
@@ -66,6 +67,23 @@ alerp :: (AffineSpace p, VectorSpace (Diff p)) =>
          p -> p -> Scalar (Diff p) -> p
 alerp p p' s = p .+^ (s *^ (p' .-. p))
 
+-- | Compute an affine combination (weighted average) of points.
+-- The first element is used as origin and is weighted
+-- such that all coefficients sum to 1. For example,
+--
+-- > affineCombo a [(0.3,b), (0.2,c)]
+--
+-- is equal to
+--
+-- > a .+^ (0.3 *^ (b .-. a) ^+^ 0.2 *^ (c .-. a))
+--
+-- and if @a@, @b@, and @c@ were in a vector space would also be equal to
+--
+-- > 0.5 *^ a ^+^ 0.3 *^ b ^+^ 0.2 *^ c
+--
+-- See also 'linearCombo' (on vector spaces).
+affineCombo :: (AffineSpace p, v ~ Diff p, VectorSpace v) => p -> [(p,Scalar v)] -> p
+affineCombo z l = z .+^ linearCombo (map (first (.-. z)) l)
 
 #define ScalarTypeCon(con,t) \
   instance con => AffineSpace (t) where \

--- a/src/Data/Basis.hs
+++ b/src/Data/Basis.hs
@@ -41,16 +41,11 @@ class VectorSpace v => HasBasis v where
 
 -- Defining property: recompose . decompose == id
 
--- | Linear combination
-linearCombo :: VectorSpace v => [(v,Scalar v)] -> v
-linearCombo ps = sumV [s *^ v | (v,s) <- ps]
-
 -- Turn a basis decomposition back into a vector.
 recompose :: HasBasis v => [(Basis v, Scalar v)] -> v
 recompose = linearCombo . fmap (first basisValue)
 
 -- recompose ps = linearCombo (first basisValue <$> ps)
-
 
 -- I don't know how to define
 -- 

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -28,7 +28,7 @@ module Data.VectorSpace
   ( module Data.AdditiveGroup
   , VectorSpace(..), (^/), (^*)
   , InnerSpace(..)
-  , lerp, magnitudeSq, magnitude, normalized, project
+  , lerp, linearCombo, magnitudeSq, magnitude, normalized, project
   ) where
 
 import Control.Applicative (liftA2)
@@ -70,6 +70,10 @@ v ^/ s = (1/s) *^ v
 -- lerp :: (VectorSpace v, s ~ Scalar v, Num s) => v -> v -> s -> v
 lerp :: VectorSpace v => v -> v -> Scalar v -> v
 lerp a b t = a ^+^ t *^ (b ^-^ a)
+
+-- | Linear combination of vectors
+linearCombo :: VectorSpace v => [(v,Scalar v)] -> v
+linearCombo ps = sumV [v ^* s | (v,s) <- ps]
 
 -- | Square of the length of a vector.  Sometimes useful for efficiency.
 -- See also 'magnitude'.


### PR DESCRIPTION
Affine combinations are useful in cases where you're blending more than two colors (colors form an affine space). Also, linear combinations are useful in cases outside the case where a finite basis exists, so they should be in Data.VectorSpace and not Data.Basis.
