### PR TITLE
Fix build with base-4.8.0.0

### DIFF
--- a/src/Data/AdditiveGroup.hs
+++ b/src/Data/AdditiveGroup.hs
@@ -20,8 +20,11 @@ module Data.AdditiveGroup
 import Prelude hiding (foldr)
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
-import Data.Foldable (Foldable,foldr)
+import Data.Foldable (Foldable)
+#endif
+import Data.Foldable (foldr)
 import Data.Complex hiding (magnitude)
 import Data.Ratio
 import Foreign.C.Types (CSChar, CInt, CShort, CLong, CLLong, CIntMax, CFloat, CDouble)

--- a/src/Data/LinearMap.hs
+++ b/src/Data/LinearMap.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeOperators, FlexibleContexts, TypeFamilies, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+{-# LANGUAGE CPP, TypeOperators, FlexibleContexts, TypeFamilies, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
 ----------------------------------------------------------------------
 -- |
@@ -21,7 +21,10 @@ module Data.LinearMap
    )
   where
 
-import Control.Applicative (Applicative,liftA2,liftA3)
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative (Applicative)
+#endif
+import Control.Applicative (liftA2, liftA3)
 import Control.Arrow       (first)
 
 import Data.MemoTrie      (HasTrie(..),(:->:))

--- a/src/Data/Maclaurin.hs
+++ b/src/Data/Maclaurin.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeOperators, MultiParamTypeClasses, UndecidableInstances
            , TypeSynonymInstances, FlexibleInstances
            , FlexibleContexts, TypeFamilies
-           , ScopedTypeVariables
+           , ScopedTypeVariables, CPP
   #-}
 
 -- The ScopedTypeVariables is there just as a bug work-around.  Without it
@@ -52,6 +52,10 @@ import Data.Basis
 import Data.LinearMap
 
 import Data.Boolean
+
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<*))
+#endif
 
 infixr 9 `D`
 -- | Tower of derivatives.


### PR DESCRIPTION
As of `base-4.8.0.0`, `Prelude` now exports several functions from `Control.Applicative` and `Data.Foldable`, which generates some warnings and errors when building `vector-space`. These CPP pragmas should fix those problems.