### PR TITLE
Fix compilation error on GHC-7.10

### DIFF
--- a/src/Data/Maclaurin.hs
+++ b/src/Data/Maclaurin.hs
@@ -2,6 +2,7 @@
            , TypeSynonymInstances, FlexibleInstances
            , FlexibleContexts, TypeFamilies
            , ScopedTypeVariables
+           , CPP
   #-}
 
 -- The ScopedTypeVariables is there just as a bug work-around.  Without it
@@ -41,6 +42,10 @@ module Data.Maclaurin
   , pairD, unpairD, tripleD, untripleD
   ) 
     where
+
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<*))
+#endif
 
 -- import Control.Applicative (liftA2)
 import Data.Function (on)


### PR DESCRIPTION
This fixes the following compilation error on GHC-7.10 and base-4.8.*:

```
src/Data/Maclaurin.hs:200:10:
Ambiguous occurrence ‘<*’
    It could refer to either ‘Prelude.<*’,
                             imported from ‘Prelude’ at src/Data/Maclaurin.hs:31:8-21
                             (and originally defined in ‘GHC.Base’)
                          or ‘Data.Boolean.<*’,
                             imported from ‘Data.Boolean’ at src/Data/Maclaurin.hs:54:1-19
```
