### PR TITLE
Fix broken links to blog posts about derivatives

### DIFF
--- a/src/Data/Horner.hs
+++ b/src/Data/Horner.hs
@@ -11,7 +11,7 @@
 -- Stability   :  experimental
 -- 
 -- Infinite derivative towers via linear maps, using the Horner
--- representation.  See blog posts <http://conal.net/blog/tag/derivatives/>.
+-- representation.  See blog posts <http://conal.net/blog/tag/derivative/>.
 ----------------------------------------------------------------------
 
 module Data.Horner

--- a/src/Data/Maclaurin.hs
+++ b/src/Data/Maclaurin.hs
@@ -24,7 +24,7 @@
 -- Stability   :  experimental
 -- 
 -- Infinite derivative towers via linear maps, using the Maclaurin
--- representation.  See blog posts <http://conal.net/blog/tag/derivatives/>.
+-- representation.  See blog posts <http://conal.net/blog/tag/derivative/>.
 ----------------------------------------------------------------------
 
 module Data.Maclaurin


### PR DESCRIPTION
Just fixed two small typos.

The links to your blog posts about derivatives was broken as the tag on your blog was 'derivative' not 'derivatives'.

Cheers,

Jose
