### PR TITLE
Give the classes default implementations, using GHC generics

### DIFF
--- a/src/Data/AdditiveGroup.hs
+++ b/src/Data/AdditiveGroup.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE TypeOperators, CPP #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 ----------------------------------------------------------------------
 -- |
 -- Module      :   Data.AdditiveGroup
@@ -31,16 +35,25 @@ import Foreign.C.Types (CSChar, CInt, CShort, CLong, CLLong, CIntMax, CFloat, CD
 
 import Data.MemoTrie
 
+import qualified GHC.Generics as Gnrx
+import GHC.Generics (Generic, (:*:)(..))
+
 infixl 6 ^+^, ^-^
 
 -- | Additive group @v@.
 class AdditiveGroup v where
   -- | The zero element: identity for '(^+^)'
   zeroV :: v
+  default zeroV :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v
+  zeroV = Gnrx.to (zeroV :: Gnrx.Rep v ())
   -- | Add vectors
   (^+^) :: v -> v -> v
+  default (^+^) :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v -> v -> v
+  v ^+^ v' = Gnrx.to (Gnrx.from v ^+^ Gnrx.from v' :: Gnrx.Rep v ())
   -- | Additive inverse
   negateV :: v -> v
+  default negateV :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v -> v
+  negateV v = Gnrx.to (negateV $ Gnrx.from v :: Gnrx.Rep v ())
   -- | Group subtraction
   (^-^) :: v -> v -> v
   v ^-^ v' = v ^+^ negateV v'
@@ -205,3 +218,21 @@ instance AdditiveGroup a => AdditiveGroup (Sum a) where
 -- argument = flip (.)
 
 -- g ~> f = result g . argument f
+
+
+
+instance AdditiveGroup a => AdditiveGroup (Gnrx.Rec0 a s) where
+  zeroV = Gnrx.K1 zeroV
+  negateV (Gnrx.K1 v) = Gnrx.K1 $ negateV v
+  Gnrx.K1 v ^+^ Gnrx.K1 w = Gnrx.K1 $ v ^+^ w
+  Gnrx.K1 v ^-^ Gnrx.K1 w = Gnrx.K1 $ v ^-^ w
+instance AdditiveGroup (f p) => AdditiveGroup (Gnrx.M1 i c f p) where
+  zeroV = Gnrx.M1 zeroV
+  negateV (Gnrx.M1 v) = Gnrx.M1 $ negateV v
+  Gnrx.M1 v ^+^ Gnrx.M1 w = Gnrx.M1 $ v ^+^ w
+  Gnrx.M1 v ^-^ Gnrx.M1 w = Gnrx.M1 $ v ^-^ w
+instance (AdditiveGroup (f p), AdditiveGroup (g p)) => AdditiveGroup ((f :*: g) p) where
+  zeroV = zeroV :*: zeroV
+  negateV (x:*:y) = negateV x :*: negateV y
+  (x:*:y) ^+^ (ξ:*:υ) = (x^+^ξ) :*: (y^+^υ)
+  (x:*:y) ^-^ (ξ:*:υ) = (x^-^ξ) :*: (y^-^υ)

--- a/src/Data/AdditiveGroup.hs
+++ b/src/Data/AdditiveGroup.hs
@@ -35,6 +35,7 @@ import Foreign.C.Types (CSChar, CInt, CShort, CLong, CLLong, CIntMax, CFloat, CD
 
 import Data.MemoTrie
 
+import Data.VectorSpace.Generic
 import qualified GHC.Generics as Gnrx
 import GHC.Generics (Generic, (:*:)(..))
 
@@ -44,16 +45,16 @@ infixl 6 ^+^, ^-^
 class AdditiveGroup v where
   -- | The zero element: identity for '(^+^)'
   zeroV :: v
-  default zeroV :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v
-  zeroV = Gnrx.to (zeroV :: Gnrx.Rep v ())
+  default zeroV :: (Generic v, AdditiveGroup (VRep v)) => v
+  zeroV = Gnrx.to (zeroV :: VRep v)
   -- | Add vectors
   (^+^) :: v -> v -> v
-  default (^+^) :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v -> v -> v
-  v ^+^ v' = Gnrx.to (Gnrx.from v ^+^ Gnrx.from v' :: Gnrx.Rep v ())
+  default (^+^) :: (Generic v, AdditiveGroup (VRep v)) => v -> v -> v
+  v ^+^ v' = Gnrx.to (Gnrx.from v ^+^ Gnrx.from v' :: VRep v)
   -- | Additive inverse
   negateV :: v -> v
-  default negateV :: (Generic v, AdditiveGroup (Gnrx.Rep v ())) => v -> v
-  negateV v = Gnrx.to (negateV $ Gnrx.from v :: Gnrx.Rep v ())
+  default negateV :: (Generic v, AdditiveGroup (VRep v)) => v -> v
+  negateV v = Gnrx.to (negateV $ Gnrx.from v :: VRep v)
   -- | Group subtraction
   (^-^) :: v -> v -> v
   v ^-^ v' = v ^+^ negateV v'

--- a/src/Data/AffineSpace.hs
+++ b/src/Data/AffineSpace.hs
@@ -149,6 +149,7 @@ newtype GenericDiff p = GenericDiff (Diff (Gnrx.Rep p ()))
 instance AdditiveGroup (Diff (Gnrx.Rep p ())) => AdditiveGroup (GenericDiff p)
 instance VectorSpace (Diff (Gnrx.Rep p ())) => VectorSpace (GenericDiff p)
 instance InnerSpace (Diff (Gnrx.Rep p ())) => InnerSpace (GenericDiff p)
+instance HasBasis (Diff (Gnrx.Rep p ())) => HasBasis (GenericDiff p)
 
 data AffineDiffProductSpace f g p = AffineDiffProductSpace
             !(Diff (f p)) !(Diff (g p)) deriving (Generic)

--- a/src/Data/AffineSpace.hs
+++ b/src/Data/AffineSpace.hs
@@ -30,6 +30,7 @@ import Control.Arrow(first)
 import Data.VectorSpace
 import Data.Basis
 
+import Data.VectorSpace.Generic
 import qualified GHC.Generics as Gnrx
 import GHC.Generics (Generic, (:*:)(..))
 
@@ -53,15 +54,15 @@ class AdditiveGroup (Diff p) => AffineSpace p where
   type Diff p = GenericDiff p
   -- | Subtract points
   (.-.)  :: p -> p -> Diff p
-  default (.-.) :: ( Generic p, Diff p ~ GenericDiff p, AffineSpace (Gnrx.Rep p ()) )
+  default (.-.) :: ( Generic p, Diff p ~ GenericDiff p, AffineSpace (VRep p) )
               => p -> p -> Diff p
   p .-. q = GenericDiff
-         $ (Gnrx.from p .-. (Gnrx.from q :: Gnrx.Rep p ()))
+         $ (Gnrx.from p .-. (Gnrx.from q :: VRep p))
   -- | Point plus vector
   (.+^)  :: p -> Diff p -> p
-  default (.+^) :: ( Generic p, Diff p ~ GenericDiff p, AffineSpace (Gnrx.Rep p ()) )
+  default (.+^) :: ( Generic p, Diff p ~ GenericDiff p, AffineSpace (VRep p) )
               => p -> Diff p -> p
-  p .+^ GenericDiff q = Gnrx.to (Gnrx.from p .+^ q :: Gnrx.Rep p ())
+  p .+^ GenericDiff q = Gnrx.to (Gnrx.from p .+^ q :: VRep p)
 
 -- | Point minus vector
 (.-^) :: AffineSpace p => p -> Diff p -> p
@@ -143,13 +144,13 @@ instance (AffineSpace p) => AffineSpace (a -> p) where
 
 
 
-newtype GenericDiff p = GenericDiff (Diff (Gnrx.Rep p ()))
+newtype GenericDiff p = GenericDiff (Diff (VRep p))
        deriving (Generic)
 
-instance AdditiveGroup (Diff (Gnrx.Rep p ())) => AdditiveGroup (GenericDiff p)
-instance VectorSpace (Diff (Gnrx.Rep p ())) => VectorSpace (GenericDiff p)
-instance InnerSpace (Diff (Gnrx.Rep p ())) => InnerSpace (GenericDiff p)
-instance HasBasis (Diff (Gnrx.Rep p ())) => HasBasis (GenericDiff p)
+instance AdditiveGroup (Diff (VRep p)) => AdditiveGroup (GenericDiff p)
+instance VectorSpace (Diff (VRep p)) => VectorSpace (GenericDiff p)
+instance InnerSpace (Diff (VRep p)) => InnerSpace (GenericDiff p)
+instance HasBasis (Diff (VRep p)) => HasBasis (GenericDiff p)
 
 data AffineDiffProductSpace f g p = AffineDiffProductSpace
             !(Diff (f p)) !(Diff (g p)) deriving (Generic)

--- a/src/Data/Basis.hs
+++ b/src/Data/Basis.hs
@@ -27,6 +27,7 @@ import Foreign.C.Types (CFloat, CDouble)
 
 import Data.VectorSpace
 
+import Data.VectorSpace.Generic
 import qualified GHC.Generics as Gnrx
 import GHC.Generics (Generic, (:*:)(..))
 
@@ -36,23 +37,23 @@ import GHC.Generics (Generic, (:*:)(..))
 class VectorSpace v => HasBasis v where
   -- | Representation of the canonical basis for @v@
   type Basis v :: *
-  type Basis v = Basis (Gnrx.Rep v ())
+  type Basis v = Basis (VRep v)
   -- | Interpret basis rep as a vector
   basisValue   :: Basis v -> v
-  default basisValue :: (Generic v, HasBasis (Gnrx.Rep v ()))
-                    => Basis (Gnrx.Rep v ()) -> v
-  basisValue b = Gnrx.to (basisValue b :: Gnrx.Rep v ())
+  default basisValue :: (Generic v, HasBasis (VRep v))
+                    => Basis (VRep v) -> v
+  basisValue b = Gnrx.to (basisValue b :: VRep v)
   -- | Extract coordinates
   decompose    :: v -> [(Basis v, Scalar v)]
-  default decompose :: (Generic v, HasBasis (Gnrx.Rep v ()))
-                    => v -> [(Basis (Gnrx.Rep v ()), Scalar (Gnrx.Rep v ()))]
-  decompose v = decompose (Gnrx.from v :: Gnrx.Rep v ())
+  default decompose :: (Generic v, HasBasis (VRep v))
+                    => v -> [(Basis (VRep v), Scalar (VRep v))]
+  decompose v = decompose (Gnrx.from v :: VRep v)
   -- | Experimental version.  More elegant definitions, and friendly to
   -- infinite-dimensional vector spaces.
   decompose'   :: v -> (Basis v -> Scalar v)
-  default decompose' :: (Generic v, HasBasis (Gnrx.Rep v ()))
-                    => v -> Basis (Gnrx.Rep v ()) -> Scalar (Gnrx.Rep v ())
-  decompose' v = decompose' (Gnrx.from v :: Gnrx.Rep v ())
+  default decompose' :: (Generic v, HasBasis (VRep v))
+                    => v -> Basis (VRep v) -> Scalar (VRep v)
+  decompose' v = decompose' (Gnrx.from v :: VRep v)
 
 -- Defining property: recompose . decompose == id
 

--- a/src/Data/Basis.hs
+++ b/src/Data/Basis.hs
@@ -40,19 +40,21 @@ class VectorSpace v => HasBasis v where
   type Basis v = Basis (VRep v)
   -- | Interpret basis rep as a vector
   basisValue   :: Basis v -> v
-  default basisValue :: (Generic v, HasBasis (VRep v))
-                    => Basis (VRep v) -> v
+  default basisValue :: (Generic v, HasBasis (VRep v), Basis (VRep v) ~ Basis v)
+                    => Basis v -> v
   basisValue b = Gnrx.to (basisValue b :: VRep v)
   -- | Extract coordinates
   decompose    :: v -> [(Basis v, Scalar v)]
-  default decompose :: (Generic v, HasBasis (VRep v))
-                    => v -> [(Basis (VRep v), Scalar (VRep v))]
+  default decompose :: ( Generic v, HasBasis (VRep v)
+                       , Scalar (VRep v) ~ Scalar v, Basis (VRep v) ~ Basis v )
+                    => v -> [(Basis v, Scalar v)]
   decompose v = decompose (Gnrx.from v :: VRep v)
   -- | Experimental version.  More elegant definitions, and friendly to
   -- infinite-dimensional vector spaces.
   decompose'   :: v -> (Basis v -> Scalar v)
-  default decompose' :: (Generic v, HasBasis (VRep v))
-                    => v -> Basis (VRep v) -> Scalar (VRep v)
+  default decompose' :: ( Generic v, HasBasis (VRep v)
+                        , Scalar (VRep v) ~ Scalar v, Basis (VRep v) ~ Basis v )
+                    => v -> Basis v -> Scalar v
   decompose' v = decompose' (Gnrx.from v :: VRep v)
 
 -- Defining property: recompose . decompose == id

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -41,6 +41,7 @@ import Data.Ratio
 import Data.AdditiveGroup
 import Data.MemoTrie
 
+import Data.VectorSpace.Generic
 import qualified GHC.Generics as Gnrx
 import GHC.Generics (Generic, (:*:)(..))
 
@@ -49,12 +50,12 @@ infixr 7 *^
 -- | Vector space @v@.
 class AdditiveGroup v => VectorSpace v where
   type Scalar v :: *
-  type Scalar v = Scalar (Gnrx.Rep v ())
+  type Scalar v = Scalar (VRep v)
   -- | Scale a vector
   (*^) :: Scalar v -> v -> v
-  default (*^) :: (Generic v, VectorSpace (Gnrx.Rep v ()))
-                    => Scalar (Gnrx.Rep v ()) -> v -> v
-  μ *^ v = Gnrx.to (μ *^ Gnrx.from v :: Gnrx.Rep v ())
+  default (*^) :: (Generic v, VectorSpace (VRep v))
+                    => Scalar (VRep v) -> v -> v
+  μ *^ v = Gnrx.to (μ *^ Gnrx.from v :: VRep v)
 
 infixr 7 <.>
 
@@ -62,9 +63,9 @@ infixr 7 <.>
 class (VectorSpace v, AdditiveGroup (Scalar v)) => InnerSpace v where
   -- | Inner/dot product
   (<.>) :: v -> v -> Scalar v
-  default (<.>) :: (Generic v, InnerSpace (Gnrx.Rep v ()))
-                    => v -> v -> Scalar (Gnrx.Rep v ())
-  v<.>w = (Gnrx.from v :: Gnrx.Rep v ()) <.> Gnrx.from w
+  default (<.>) :: (Generic v, InnerSpace (VRep v))
+                    => v -> v -> Scalar (VRep v)
+  v<.>w = (Gnrx.from v :: VRep v) <.> Gnrx.from w
 
 infixr 7 ^/
 infixl 7 ^*

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -61,6 +61,9 @@ infixr 7 <.>
 class (VectorSpace v, AdditiveGroup (Scalar v)) => InnerSpace v where
   -- | Inner/dot product
   (<.>) :: v -> v -> Scalar v
+  default (<.>) :: (Generic v, InnerSpace (Gnrx.Rep v ()))
+                    => v -> v -> Scalar (Gnrx.Rep v ())
+  v<.>w = (Gnrx.from v :: Gnrx.Rep v ()) <.> Gnrx.from w
 
 infixr 7 ^/
 infixl 7 ^*
@@ -236,3 +239,12 @@ instance (VectorSpace (f p), VectorSpace (g p), Scalar (f p) ~ Scalar (g p))
          => VectorSpace ((f :*: g) p) where
   type Scalar ((f:*:g) p) = Scalar (f p)
   μ *^ (x:*:y) = μ*^x :*: μ*^y
+
+instance InnerSpace a => InnerSpace (Gnrx.Rec0 a s) where
+  Gnrx.K1 v <.> Gnrx.K1 w = v<.>w
+instance InnerSpace (f p) => InnerSpace (Gnrx.M1 i c f p) where
+  Gnrx.M1 v <.> Gnrx.M1 w = v<.>w
+instance ( InnerSpace (f p), InnerSpace (g p)
+         , Scalar (f p) ~ Scalar (g p), Num (Scalar (f p)) )
+         => InnerSpace ((f :*: g) p) where
+  (x:*:y) <.> (ξ:*:υ) = x<.>ξ + y<.>υ

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -53,8 +53,8 @@ class AdditiveGroup v => VectorSpace v where
   type Scalar v = Scalar (VRep v)
   -- | Scale a vector
   (*^) :: Scalar v -> v -> v
-  default (*^) :: (Generic v, VectorSpace (VRep v))
-                    => Scalar (VRep v) -> v -> v
+  default (*^) :: (Generic v, VectorSpace (VRep v), Scalar (VRep v) ~ Scalar v)
+                    => Scalar v -> v -> v
   μ *^ v = Gnrx.to (μ *^ Gnrx.from v :: VRep v)
 
 infixr 7 <.>
@@ -63,8 +63,8 @@ infixr 7 <.>
 class (VectorSpace v, AdditiveGroup (Scalar v)) => InnerSpace v where
   -- | Inner/dot product
   (<.>) :: v -> v -> Scalar v
-  default (<.>) :: (Generic v, InnerSpace (VRep v))
-                    => v -> v -> Scalar (VRep v)
+  default (<.>) :: (Generic v, InnerSpace (VRep v), Scalar (VRep v) ~ Scalar v)
+                    => v -> v -> Scalar v
   v<.>w = (Gnrx.from v :: VRep v) <.> Gnrx.from w
 
 infixr 7 ^/

--- a/src/Data/VectorSpace.hs
+++ b/src/Data/VectorSpace.hs
@@ -49,6 +49,7 @@ infixr 7 *^
 -- | Vector space @v@.
 class AdditiveGroup v => VectorSpace v where
   type Scalar v :: *
+  type Scalar v = Scalar (Gnrx.Rep v ())
   -- | Scale a vector
   (*^) :: Scalar v -> v -> v
   default (*^) :: (Generic v, VectorSpace (Gnrx.Rep v ()))

--- a/src/Data/VectorSpace/Generic.hs
+++ b/src/Data/VectorSpace/Generic.hs
@@ -1,0 +1,20 @@
+-- |
+-- Module      :   Data.VectorSpace.Generic
+-- Copyright   :  (c) Conal Elliott and Justus Sagemüller 2017
+-- License     :  BSD3
+-- 
+-- Maintainer  :  conal@conal.net, (@) jsagemue $ uni-koeln.de
+-- Stability   :  experimental
+-- 
+-- Underpinnings of the type that represents vector / affine / etc. spaces
+-- with GHC generics
+
+module Data.VectorSpace.Generic where
+
+
+import qualified GHC.Generics as Gnrx
+
+import Data.Void
+
+
+type VRep v = Gnrx.Rep v Void

--- a/vector-space.cabal
+++ b/vector-space.cabal
@@ -44,6 +44,8 @@ Library
                      Data.Derivative
                      Data.Cross
                      Data.AffineSpace
+  Other-Modules:     
+                     Data.VectorSpace.Generic
 
 
   -- This library relies on type families working as well as in 6.10.


### PR DESCRIPTION
Any product type of vector spaces is a vector space, namely a direct sum. This is already witnessed by the tuple instances, but plain tuples are problematic for serious applications (both because they are not very descriptive type-wise, and because boxing isn't great for performance). But for any custom ADT, users would so far have to write their own instances of the classes. If you need all of `AffineSpace` and `HasBasis`, that can be quite a bit of code.

Of course this problem is not specific to `vector-space`. GHC has taken mighty steps for making it easy to define such instances in the last years, and many libraries already exploit this: [GHC generics](http://hackage.haskell.org/package/base-4.9.1.0/docs/GHC-Generics.html). It turns out we can also do that for vector spaces. This PR makes it possible to write e.g.
```haskell
{-# LANGUAGE DeriveGeneric #-}
data Twice v = Twice v v deriving (Generic)
instance AdditiveGroup v => AdditiveGroup (Twice v)
instance VectorSpace v => VectorSpace (Twice v)
...
instance AffineSpace p => AffineSpace (Twice p)
```
without needing to worry about the methods at all.

For monomorphic types, you can even use
```haskell
{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
data ℝ² = ℝ² !Double !Double deriving (Generic, AdditiveGroup, VectorSpace)
```
however that doesn't seem to work reliably yet, at least not in GHC<=7.10 and even in 8.0 doesn't work for `InnerSpace`, `HasBasis` and `AffineSpace`.

I haven't tested it with compilers other that these two. Quite possibly there are problems breaking the build with older versions, which might warrant wrapping the additions in CPP conditionals. Tell me if I should do that.