### PR TITLE
Fix build error on GHC <7.9

### DIFF
--- a/vector-space.cabal
+++ b/vector-space.cabal
@@ -52,6 +52,9 @@ Library
   if impl(ghc < 6.10) {
     buildable: False
   }
+  if !impl(ghc >= 7.9) {
+    Build-Depends: void >= 0.4
+  }
   ghc-options:         -Wall -O2
 --  ghc-prof-options:    -prof -auto-all 
 


### PR DESCRIPTION
GHC <7.9 failed to compile `src/Data/VectorSpace/Generic.hs` with the following error, because `Data.Void` module is provided by separate `void` package instead of the `base` package.
```
src/Data/VectorSpace/Generic.hs:17:8:
    Could not find module ‘Data.Void’
    It is a member of the hidden package ‘void-0.7.2’.
    Perhaps you need to add ‘void’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

This PR fixes the problem.
