### PR TITLE
Restore compat with GHC 7.4 / base-4.5

### DIFF
--- a/vector-space.cabal
+++ b/vector-space.cabal
@@ -1,6 +1,6 @@
 Name:                vector-space
 Version:             0.13
-Cabal-Version:       >= 1.6
+Cabal-Version:       >= 1.8
 Synopsis:            Vector & affine spaces, linear maps, and derivatives
 Category:            math
 Description:
@@ -51,6 +51,9 @@ Library
   -- This library relies on type families working as well as in 6.10.
   if impl(ghc < 6.10) {
     buildable: False
+  }
+  if !impl(ghc >= 7.6) {
+    Build-Depends: ghc-prim >= 0.2
   }
   if !impl(ghc >= 7.9) {
     Build-Depends: void >= 0.4


### PR DESCRIPTION
Otherwise you'd get

```
Build profile: -w ghc-7.4.2 -O1
In order, the following will be built (use -v for more details):
 - vector-space-0.13 (lib:vector-space) (first run)
Configuring vector-space-0.13...
Preprocessing library for vector-space-0.13..
Building library for vector-space-0.13..

src/Data/AdditiveGroup.hs:43:8:
    Could not find module `GHC.Generics'
    It is a member of the hidden package `ghc-prim'.
    Perhaps you need to add `ghc-prim' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

I've already revised the affected releases on Hackage according, e.g.

- https://hackage.haskell.org/package/vector-space-0.13/revisions/
- https://hackage.haskell.org/package/vector-space-0.12/revisions/